### PR TITLE
insert newrelic initialization stuff

### DIFF
--- a/turbogears/startup.py
+++ b/turbogears/startup.py
@@ -330,7 +330,7 @@ class SimpleWSGIServer(CherryPyWSGIServer):
         conf = cherrypy.config.get
         wsgi_app = newrelic.agent.WSGIApplicationWrapper(wsgiApp)
         bind_addr = (conf('server.socket_host'), conf('server.socket_port'))
-        CherryPyWSGIServer.__init__(self, bind_addr, wsgi_app,
+        super(SimpleWSGIServer, self).__init__(bind_addr, wsgi_app,
             conf("server.thread_pool"), conf("server.socket_host"),
             request_queue_size=conf("server.socket_queue_size"),
             timeout=conf('server.socket_timeout'),)


### PR DESCRIPTION
To be used with this: https://github.com/OnShift/OnShift/pull/624

This tells New Relic to start up and where the actual wsgi application callable is.  See: https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-integration

Note that you have to have the 'NEW_RELIC_CONFIG_FILE' environment variable set in order for this to work, or you can pass in the path of the config file as an argument to newrelic.agent.initialize().  I'll leave that up to you guys to handle.
