### PR TITLE
Prevent deadlocking on the visit table

### DIFF
--- a/turbogears/visit/sovisit.py
+++ b/turbogears/visit/sovisit.py
@@ -84,7 +84,7 @@ class SqlObjectVisitManager(BaseVisitManager):
                         {visit_class.q.expiry.fieldName: expiry},
                         where=(visit_class.q.visit_key==visit_key))
                     conn.query(conn.sqlrepr(u))
-                hub.commit()
+                    hub.commit()
             except:
                 hub.rollback()
                 raise


### PR DESCRIPTION
Indents hub.commit. More transactions, same number of writes

@fuhrysteve @EricWorkman 