### PR TITLE
Added functions to controllers from TurboGears docs

### DIFF
--- a/turbogears/controllers.py
+++ b/turbogears/controllers.py
@@ -596,6 +596,23 @@ def check_app_root():
     request.app_root = app_root
 
 
+def get_server_name(): 
+    """Return name of the server this application runs on. 
+ 
+    Respects 'Host' and 'X-Forwarded-Host' header. 
+ 
+    See the docstring of the 'absolute_url' function for more information. 
+ 
+    """ 
+    get = config.get 
+    h = request.headers 
+    host = get('tg.url_domain') or h.get('X-Forwarded-Host', h.get('Host')) 
+    if not host: 
+        host = '%s:%s' % (get('server.socket_host', 'localhost'), 
+            get('server.socket_port', 8080)) 
+    return host 
+
+
 def absolute_url(tgpath='/', params=None, **kw): 
     """Return absolute URL (including schema and host to this server). 
  

--- a/turbogears/controllers.py
+++ b/turbogears/controllers.py
@@ -596,6 +596,45 @@ def check_app_root():
     request.app_root = app_root
 
 
+def absolute_url(tgpath='/', params=None, **kw): 
+    """Return absolute URL (including schema and host to this server). 
+ 
+    Tries to account for 'Host' header and reverse proxying 
+    ('X-Forwarded-Host'). 
+ 
+    The host name is determined this way: 
+ 
+    * If the config setting 'tg.url_domain' is set and non-null, use this value. 
+    * Else, if the 'base_url_filter.use_x_forwarded_host' config setting is 
+      True, use the value from the 'Host' or 'X-Forwarded-Host' request header. 
+    * Else, if config setting 'base_url_filter.on' is True and 
+      'base_url_filter.base_url' is non-null, use its value for the host AND 
+      scheme part of the URL. 
+    * As a last fallback, use the value of 'server.socket_host' and 
+      'server.socket_port' config settings (defaults to 'localhost:8080'). 
+ 
+    The URL scheme ('http' or 'http') used is determined in the following way: 
+ 
+    * If 'base_url_filter.base_url' is used, use the scheme from this URL. 
+    * If there is a 'X-Use-SSL' request header, use 'https'. 
+    * Else, if the config setting 'tg.url_scheme' is set, use its value. 
+    * Else, use the value of 'cherrypy.request.scheme'. 
+ 
+    """ 
+    get = config.get 
+    use_xfh = get('base_url_filter.use_x_forwarded_host', False) 
+    if request.headers.get('X-Use-SSL'): 
+        scheme = 'https' 
+    else: 
+        scheme = get('tg.url_scheme') 
+    if not scheme: 
+        scheme = request.scheme 
+    base_url = '%s://%s' % (scheme, get_server_name()) 
+    if get('base_url_filter.on', False) and not use_xfh: 
+        base_url = get('base_url_filter.base_url').rstrip('/') 
+    return '%s%s' % (base_url, url(tgpath, params, **kw)) 
+
+
 def redirect(redirect_path, redirect_params=None, **kw):
     """Redirect (via cherrypy.HTTPRedirect).
 


### PR DESCRIPTION
@will-mooney-3 @fuhrysteve 

For the turbogears scheduler to use the auth_app, it needs to be able to tell the auth_app where to redirect back to once the user has logged in. The Turbogears documentation lists the functions "absolute_url" and "get_server_name" all the way back to version 1.0, but for some reason they're missing from OnShift's TurboGears fork.

I copied the code for both functions from TurboGears's site: http://www.turbogears.org/1.0/docs/api/turbogears.controllers-pysrc.html#get_server_name