### PR TITLE
remove tg_widgets insertion into links and possibly introduce problems

### DIFF
--- a/turbogears/widgets/base.py
+++ b/turbogears/widgets/base.py
@@ -560,8 +560,7 @@ class Link(Resource):
 
     def update_params(self, d):
         super(Link, self).update_params(d)
-        d["link"] = "/%stg_widgets/%s/%s" % (startup.webpath,
-            self.mod, self.name)
+        d["link"] = "%s/%s" % (self.mod, self.name) if self.mod and self.name != 'widget' else "%s" % self.mod
 
     def __hash__(self):
         return hash(self.mod + self.name)


### PR DESCRIPTION
@bmoar @EricWorkman @will-mooney-3 @fuhrysteve 
This is the onshift/turbogears portion to remove the need for the /tg_widgets/bazman symlinks on prod servers, and I'm fairly confident it'll work, kinda.

Must be merged along with https://github.com/OnShift/OnShift/pull/1855
