### PR TITLE
Nt 76 togglable memory profiling to fluentd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 dist
 TurboGears.egg-info
+.idea

--- a/turbogears/controllers.py
+++ b/turbogears/controllers.py
@@ -19,7 +19,6 @@ from memory_profiler_setup import profile_expose_method
 
 log = logging.getLogger("turbogears.controllers")
 
-
 if config.get("session_filter.on", None):
     if config.get("session_filter.storage_type", None) == "PostgreSQL":
         import psycopg2
@@ -355,7 +354,7 @@ def expose(template=None, validators=None, allow_json=None, html=None,
                                 *args, **kw)
                 else:
                     request.in_transaction = True
-                    output = profile_expose_method(_pass_through_expose_method, _profile_me, accept, args, func, kw)
+                    output = profile_expose_method(_profiled_method_wrapper, accept, args, func, kw)
                 return output
             func.exposed = True
             func._ruleinfo = []
@@ -386,16 +385,10 @@ def expose(template=None, validators=None, allow_json=None, html=None,
     return weak_signature_decorator(entangle)
 
 
-def _pass_through_expose_method(accept, args, func, kw):
+def _profiled_method_wrapper(accept, args, func, kw):
     return database.run_with_transaction(
              func._expose, func, accept, func._allow_json,
              *args, **kw)
-
-
-def _profile_me(_output, _func, _accept, _args, _kwargs):
-    _output['output'] = database.run_with_transaction(
-        _func._expose, _func, _accept, _func._allow_json,
-        *_args, **_kwargs)
 
 
 def _execute_func(func, template, format, content_type, mapping, fragment, args, kw):

--- a/turbogears/controllers.py
+++ b/turbogears/controllers.py
@@ -354,7 +354,7 @@ def expose(template=None, validators=None, allow_json=None, html=None,
                                 *args, **kw)
                 else:
                     request.in_transaction = True
-                    output = profile_expose_method(_profiled_method_wrapper, accept, args, func, kw)
+                    output = profile_expose_method(_run_with_transaction, accept, args, func, kw)
                 return output
             func.exposed = True
             func._ruleinfo = []
@@ -385,7 +385,7 @@ def expose(template=None, validators=None, allow_json=None, html=None,
     return weak_signature_decorator(entangle)
 
 
-def _profiled_method_wrapper(accept, args, func, kw):
+def _run_with_transaction(accept, args, func, kw):
     return database.run_with_transaction(
              func._expose, func, accept, func._allow_json,
              *args, **kw)

--- a/turbogears/memory_profiler_setup.py
+++ b/turbogears/memory_profiler_setup.py
@@ -13,7 +13,7 @@ FLUENTD_HOST_NAME = os.environ.get('FLUENTD_HOST_NAME', 'fluentd')
 _fluentd_port_str = os.environ.get('FLUENTD_PORT', '24224')
 FLUENTD_PORT = int(_fluentd_port_str) if _fluentd_port_str.isdigit() else 24224
 TURBOGEARS_PROFILER_FIFO_PATH = os.environ.get('TURBOGEARS_PROFILER_FIFO_PATH',
-                                               tempfile.gettempdir()+'/turbogears_memory_config_fifo')
+                                               '{}/turbogears_memory_config_fifo'.format(tempfile.gettempdir()))
 TURBOGEARS_PROFILER_LOG_TO_CONSOLE = os.environ.get('TURBOGEARS_PROFILER_LOG_TO_CONSOLE', 'False') == 'True'
 
 # setup thread log handler to monitor state of memory profile logging
@@ -43,10 +43,12 @@ memory_log.addHandler(mem_fluent_hdlr)
 
 memory_log.setLevel(logging.INFO)
 
-thread_log.info('turbogears memory profiler settings: FLUENTD_HOST_NAME='+FLUENTD_HOST_NAME +
-                ' FLUENTD_PORT='+str(FLUENTD_PORT) + ' TURBOGEARS_PROFILER_FIFO_PATH=' +
-                TURBOGEARS_PROFILER_FIFO_PATH + ' TURBOGEARS_PROFILER_LOG_TO_CONSOLE=' +
-                str(TURBOGEARS_PROFILER_LOG_TO_CONSOLE))
+thread_log.info('turbogears memory profiler settings: FLUENTD_HOST_NAME={} FLUENTD_PORT={} '
+                'TURBOGEARS_PROFILER_FIFO_PATH={} '
+                'TURBOGEARS_PROFILER_LOG_TO_CONSOLE={}'.format(FLUENTD_HOST_NAME,FLUENTD_PORT,
+                                                               TURBOGEARS_PROFILER_FIFO_PATH,
+                                                               TURBOGEARS_PROFILER_LOG_TO_CONSOLE)
+                )
 
 
 def toggle_memory_profile_via_fifo(_thread_log):
@@ -57,7 +59,7 @@ def toggle_memory_profile_via_fifo(_thread_log):
     :param _thread_log: console logger
     :return: 
     """
-    _thread_log.info('started toggle_memory_profile_via_fifo thread PID(' + str(os.getpid()) + ')')
+    _thread_log.info('started toggle_memory_profile_via_fifo thread PID({})'.format(os.getpid()))
     fifo_name = TURBOGEARS_PROFILER_FIFO_PATH
     if not os.path.exists(fifo_name):
         os.mkfifo(fifo_name)
@@ -65,14 +67,14 @@ def toggle_memory_profile_via_fifo(_thread_log):
         with open(fifo_name, 'r') as config_fifo:
             _thread_log.info('opened FIFO toggle_memory_profile_via_fifo thread')
             line = config_fifo.readline()[:-1]
-            _thread_log.info('READ LINE toggle_memory_profile_via_fifo thread ====>' + line)
+            _thread_log.info('READ LINE toggle_memory_profile_via_fifo thread ====>{}'.format(line))
             toggle_memory_profile_logging(_thread_log)
 
 
 def create_config_thread(_thread_log):
     # start configuration pipe monitoring thread on import
     _config_thread = threading.Thread(target=toggle_memory_profile_via_fifo, args=(_thread_log,),
-                                     name='toggle_memory_profile_via_fifo')
+                                      name='toggle_memory_profile_via_fifo')
     _config_thread.setDaemon(True)
     _config_thread.start()
     return _config_thread
@@ -99,7 +101,7 @@ def toggle_memory_profile_logging(_thread_log):
     """
     memory_profile_logging_on = get_memory_profile_logging_on()
     os.environ['MEMORY_PROFILE_LOGGING_ON'] = str(not memory_profile_logging_on)
-    _thread_log.info(' SET MEMORY_PROFILE_LOGGING_ON = ' + str(not memory_profile_logging_on))
+    _thread_log.info(' SET MEMORY_PROFILE_LOGGING_ON={}'.format(not memory_profile_logging_on))
 
 
 def profile_expose_method(profiled_method_wrapper, accept, args, func, kw):
@@ -137,7 +139,7 @@ def profile_expose_method(profiled_method_wrapper, accept, args, func, kw):
                                    'controller_class': controller_class,
                                    'endpoint': func.__name__})
         except Exception as e:
-            thread_log.exception("failed to log memory profile for " + func.__name__)
+            thread_log.exception("failed to log memory profile for {}".foramt(func.__name__))
     else:
         output = profiled_method_wrapper(accept, args, func, kw)
     return output

--- a/turbogears/memory_profiler_setup.py
+++ b/turbogears/memory_profiler_setup.py
@@ -8,16 +8,18 @@ import tempfile
 from fluent import handler
 from memory_profiler import memory_usage
 
-memory_log = logging.getLogger("memory_profiler")
-mem_out_hdlr = logging.StreamHandler(sys.stdout)
-mem_out_hdlr.setLevel(logging.INFO)
-memory_log.addHandler(mem_out_hdlr)
-
+# setup thread log handler to monitor state of memory profile logging
 thread_log = logging.getLogger("memory_profiler_thread_log")
 thread_log_hdlr = logging.StreamHandler(sys.stdout)
 thread_log_hdlr.setLevel(logging.INFO)
 thread_log.addHandler(thread_log_hdlr)
 thread_log.setLevel(logging.INFO)
+
+# set up memory profiler log handler to feed memory profiler output into fluentd
+memory_log = logging.getLogger("memory_profiler")
+mem_out_hdlr = logging.StreamHandler(sys.stdout)
+mem_out_hdlr.setLevel(logging.INFO)
+memory_log.addHandler(mem_out_hdlr)
 
 fluentd_format = {
     'hostename': '%(hostname)s',
@@ -33,54 +35,110 @@ memory_log.addHandler(mem_fluent_hdlr)
 memory_log.setLevel(logging.INFO)
 
 
-def toggle_memory_profile_via_fifo(thread_log):
-    thread_log.info('started toggle_memory_profile_via_fifo thread')
+def toggle_memory_profile_via_fifo(_thread_log):
+    """
+    execution body of a thread that monitors any input on a named pipe located at /tmp/bazman_memory_config_fifo.
+    Whenever any value with a new line is pushed into the FIFO the thread will trigger the toggle of an environment
+    variable and turn memory profiling ON or OFF
+    :param _thread_log: console logger
+    :return: 
+    """
+    _thread_log.info('started toggle_memory_profile_via_fifo thread PID(' + str(os.getpid()) + ')')
     fifo_name = tempfile.gettempdir()+'/bazman_memory_config_fifo'
     if not os.path.exists(fifo_name):
         os.mkfifo(fifo_name)
     while True:
         with open(fifo_name, 'r') as config_fifo:
-            thread_log.info('opened FIFO toggle_memory_profile_via_fifo thread')
+            _thread_log.info('opened FIFO toggle_memory_profile_via_fifo thread')
             line = config_fifo.readline()[:-1]
-            thread_log.info('READ LINE toggle_memory_profile_via_fifo thread ====>' + line)
-            toggle_memory_profile_logging(thread_log)
+            _thread_log.info('READ LINE toggle_memory_profile_via_fifo thread ====>' + line)
+            toggle_memory_profile_logging(_thread_log)
 
-config_thread = threading.Thread(target=toggle_memory_profile_via_fifo, args=(thread_log,), name='toggle_memory_profile_via_fifo')
-config_thread.setDaemon(True)
-config_thread.start()
+
+def create_config_thread(_thread_log):
+    # start configuration pipe monitoring thread on import
+    _config_thread = threading.Thread(target=toggle_memory_profile_via_fifo, args=(_thread_log,),
+                                     name='toggle_memory_profile_via_fifo')
+    _config_thread.setDaemon(True)
+    _config_thread.start()
+    return _config_thread
+
+try:
+    config_thread
+except NameError:
+    config_thread = create_config_thread(thread_log)
 
 
 def get_memory_profile_logging_on():
+    """
+    Lazy loaded environment variable evaluated as a boolean
+    :return: returns False if 'False' or absent, return True if set to 'True'
+    """
     return os.environ.get('MEMORY_PROFILE_LOGGING_ON', 'False') == 'True'
 
 
-def toggle_memory_profile_logging(thread_log):
+def toggle_memory_profile_logging(_thread_log):
+    """
+    Toggles and logs to console the environment variable that enables memory profiling 
+    :param _thread_log: console logger
+    :return: 
+    """
     memory_profile_logging_on = get_memory_profile_logging_on()
     os.environ['MEMORY_PROFILE_LOGGING_ON'] = str(not memory_profile_logging_on)
-    thread_log.info(' SET MEMORY_PROFILE_LOGGING_ON = ' + str(not memory_profile_logging_on))
+    _thread_log.info(' SET MEMORY_PROFILE_LOGGING_ON = ' + str(not memory_profile_logging_on))
 
 
-def profile_expose_method(pass_through_expose_method, test_expose_method, accept, args, func, kw):
+def profile_expose_method(profiled_method_wrapper, accept, args, func, kw):
+    """
+    Targeted to profile a specific method that wraps HTTP request processing endpoints into database context.  
+    :param profiled_method_wrapper: method wrapped around profiled call to be passed in to memory profiler
+    :param accept: param specific to profiled call
+    :param args: args of a function that is being wrapped by a profiled method
+    :param func: function that is being wrapped by a profiled method
+    :param kw: kwargs of a function that is being wrapped by a profiled method
+    :return: output of a profiled method without modification
+    """
     if get_memory_profile_logging_on():
         profile_output = {'output': {}}
-        memory_profile = memory_usage((test_expose_method, (profile_output, func, accept, args, kw), {}), interval=0.1)
-        # _profile_me(profile_output, func, accept, args, kw)
+        memory_profile = memory_usage((_profile_me,
+                                       (profile_output, profiled_method_wrapper, func, accept, args, kw),
+                                       {}),
+                                      interval=0.1)
         output = profile_output['output']
-        controller_class = args[0].__class__.__name__ if args and len(args) > 0 else ''
-        message = json.dumps({'log_type': 'memory_profile',
-                              'name': func.__name__,
-                              'module': func.__module__,
-                              'mem_profile': memory_profile,
-                              'min': min(memory_profile),
-                              'max': max(memory_profile),
-                              'diff': max(memory_profile) - min(memory_profile),
-                              'leaked': memory_profile[-1] - memory_profile[0],
-                              'args': [arg for arg in args[1:]],  # exclude self
-                              'kwargs': kw})
-        memory_log.info(message,
-                        extra={'controller_module': func.__module__,
-                               'controller_class': controller_class,
-                               'endpoint': func.__name__})
+        try:
+            controller_class = args[0].__class__.__name__ if args and len(args) > 0 else ''
+            message = json.dumps({'log_type': 'memory_profile',
+                                  'proc_id': os.getpid(),
+                                  'name': func.__name__,
+                                  'module': func.__module__,
+                                  'mem_profile': memory_profile,
+                                  'min': min(memory_profile),
+                                  'max': max(memory_profile),
+                                  'diff': max(memory_profile) - min(memory_profile),
+                                  'leaked': memory_profile[-1] - memory_profile[0],
+                                  'args': [arg for arg in args[1:]],  # exclude self
+                                  'kwargs': kw})
+            memory_log.info(message,
+                            extra={'controller_module': func.__module__,
+                                   'controller_class': controller_class,
+                                   'endpoint': func.__name__})
+        except Exception as e:
+            thread_log.exception("failed to log memory profile for " + func.__name__)
     else:
-        output = pass_through_expose_method(accept, args, func, kw)
+        output = profiled_method_wrapper(accept, args, func, kw)
     return output
+
+
+def _profile_me(_output, pass_through_expose_method, _func, _accept, _args, _kwargs):
+    """
+    Wraps method to return output through a parameter since memory_usage call does not support return of a value from a 
+    profiled method
+    :param _output: 
+    :param pass_through_expose_method: 
+    :param _func: 
+    :param _accept: 
+    :param _args: 
+    :param _kwargs: 
+    :return: None as the result returned through an _output dictionary value and picked out in above method 
+    """
+    _output['output'] = pass_through_expose_method(_accept, _args, _func, _kwargs)

--- a/turbogears/memory_profiler_setup.py
+++ b/turbogears/memory_profiler_setup.py
@@ -1,0 +1,86 @@
+import logging
+import signal
+import os
+import sys
+import json
+import threading
+import tempfile
+from fluent import handler
+from memory_profiler import memory_usage
+
+memory_log = logging.getLogger("memory_profiler")
+mem_out_hdlr = logging.StreamHandler(sys.stdout)
+mem_out_hdlr.setLevel(logging.INFO)
+memory_log.addHandler(mem_out_hdlr)
+
+thread_log = logging.getLogger("memory_profiler_thread_log")
+thread_log_hdlr = logging.StreamHandler(sys.stdout)
+thread_log_hdlr.setLevel(logging.INFO)
+thread_log.addHandler(thread_log_hdlr)
+thread_log.setLevel(logging.INFO)
+
+fluentd_format = {
+    'hostename': '%(hostname)s',
+    'where': '%(controller_module)s.%(controller_class)s.%(endpoint)s'
+}
+
+mem_fluent_hdlr = handler.FluentHandler('bazman.memory_profiler', host='fluentd', port=24224)
+mem_fluentd_formatter = handler.FluentRecordFormatter(fluentd_format)
+mem_fluent_hdlr.setFormatter(mem_fluentd_formatter)
+mem_fluent_hdlr.setLevel(logging.INFO)
+memory_log.addHandler(mem_fluent_hdlr)
+
+memory_log.setLevel(logging.INFO)
+
+
+def toggle_memory_profile_via_fifo(thread_log):
+    thread_log.info('started toggle_memory_profile_via_fifo thread')
+    fifo_name = tempfile.gettempdir()+'/bazman_memory_config_fifo'
+    if not os.path.exists(fifo_name):
+        os.mkfifo(fifo_name)
+    while True:
+        with open(fifo_name, 'r') as config_fifo:
+            thread_log.info('opened FIFO toggle_memory_profile_via_fifo thread')
+            line = config_fifo.readline()[:-1]
+            thread_log.info('READ LINE toggle_memory_profile_via_fifo thread ====>' + line)
+            toggle_memory_profile_logging(thread_log)
+
+config_thread = threading.Thread(target=toggle_memory_profile_via_fifo, args=(thread_log,), name='toggle_memory_profile_via_fifo')
+config_thread.setDaemon(True)
+config_thread.start()
+
+
+def get_memory_profile_logging_on():
+    return os.environ.get('MEMORY_PROFILE_LOGGING_ON', 'False') == 'True'
+
+
+def toggle_memory_profile_logging(thread_log):
+    memory_profile_logging_on = get_memory_profile_logging_on()
+    os.environ['MEMORY_PROFILE_LOGGING_ON'] = str(not memory_profile_logging_on)
+    thread_log.info(' SET MEMORY_PROFILE_LOGGING_ON = ' + str(not memory_profile_logging_on))
+
+
+def profile_expose_method(pass_through_expose_method, test_expose_method, accept, args, func, kw):
+    if get_memory_profile_logging_on():
+        profile_output = {'output': {}}
+        memory_profile = memory_usage((test_expose_method, (profile_output, func, accept, args, kw), {}), interval=0.1)
+        # _profile_me(profile_output, func, accept, args, kw)
+        output = profile_output['output']
+        controller_class = args[0].__class__.__name__ if args and len(args) > 0 else ''
+        message = json.dumps({'log_type': 'memory_profile',
+                              'name': func.__name__,
+                              'module': func.__module__,
+                              'mem_profile': memory_profile,
+                              'min': min(memory_profile),
+                              'max': max(memory_profile),
+                              'diff': max(memory_profile) - min(memory_profile),
+                              'leaked': memory_profile[-1] - memory_profile[0],
+                              'args': [arg for arg in args[1:]],  # exclude self
+                              'kwargs': kw})
+        memory_log.info(message,
+                        extra={'controller_module': func.__module__,
+                               'controller_class': controller_class,
+                               'endpoint': func.__name__})
+    else:
+        output = pass_through_expose_method(accept, args, func, kw)
+    return output


### PR DESCRIPTION
Added memory profiling using memory_profiler python library that can be turned on and off via echo into named FIFO without restarting the process.