### PR TITLE
NT-76 adding memory profiler exclusion flag

### DIFF
--- a/turbogears/controllers.py
+++ b/turbogears/controllers.py
@@ -259,7 +259,8 @@ def _build_rules(func):
 
 def expose(template=None, validators=None, allow_json=None, html=None,
            format=None, content_type=None, inputform=None, fragment=False,
-           as_format="default", mapping=None, accept_format=None):
+           as_format="default", mapping=None, accept_format=None,
+           exclude_from_memory_profiling=False):
     """Exposes a method to the web.
 
     By putting the expose decorator on a method, you tell TurboGears that
@@ -324,7 +325,8 @@ def expose(template=None, validators=None, allow_json=None, html=None,
             applied to that arg
     @keyparam inputform deprecated. A form object that generates the
             input to this method
-
+    @keyparam exclude_from_memory_profiling allows to exclude individual end points from memory profiling. Can be 
+            used for performance or in case profiling generates errors
     """
     if html:
         template = html
@@ -354,7 +356,8 @@ def expose(template=None, validators=None, allow_json=None, html=None,
                                 *args, **kw)
                 else:
                     request.in_transaction = True
-                    output = profile_expose_method(_run_with_transaction, accept, args, func, kw)
+                    output = profile_expose_method(_run_with_transaction, accept, args, func, kw,
+                                                   exclude_from_memory_profiling)
                 return output
             func.exposed = True
             func._ruleinfo = []

--- a/turbogears/memory_profiler_setup.py
+++ b/turbogears/memory_profiler_setup.py
@@ -104,7 +104,7 @@ def toggle_memory_profile_logging(_thread_log):
     _thread_log.info(' SET MEMORY_PROFILE_LOGGING_ON={}'.format(not memory_profile_logging_on))
 
 
-def profile_expose_method(profiled_method_wrapper, accept, args, func, kw):
+def profile_expose_method(profiled_method_wrapper, accept, args, func, kw, exclude_from_memory_profiling):
     """
     Targeted to profile a specific method that wraps HTTP request processing endpoints into database context.  
     :param profiled_method_wrapper: method wrapped around profiled call to be passed in to memory profiler
@@ -114,7 +114,7 @@ def profile_expose_method(profiled_method_wrapper, accept, args, func, kw):
     :param kw: kwargs of a function that is being wrapped by a profiled method
     :return: output of a profiled method without modification
     """
-    if get_memory_profile_logging_on():
+    if not exclude_from_memory_profiling and get_memory_profile_logging_on():
         profile_output = {'output': {}}
         memory_profile = memory_usage((_profile_me,
                                        (profile_output, profiled_method_wrapper, func, accept, args, kw),


### PR DESCRIPTION
Found a single method that exhibits unexpected behavior when profiled. Adding an explicit exclusion flag to allow for omission of such end points.