### PR TITLE
NT-76 adding package wide profiling disable

### DIFF
--- a/turbogears/__init__.py
+++ b/turbogears/__init__.py
@@ -32,6 +32,7 @@ for entrypoint in extensions:
 
 i18n.install() # adds _ (gettext) to builtins namespace
 
+IMPORT_THIS_TO_EXCLUDE_PACKAGE_FROM_MEMORY_PROFILING = True
 
 __all__ = ["url", "expose", "redirect", "validate", "flash",
            "error_handler", "exception_handler",

--- a/turbogears/release.py
+++ b/turbogears/release.py
@@ -28,7 +28,7 @@ problem.
     http://svn.turbogears.org/trunk#egg=turbogears-dev
 """
 
-version = "1.0.11.3"
+version = "1.0.11.5"
 description = "Front-to-back, open-source, rapid web development framework"
 long_description = __doc__
 author = "Kevin Dangoor"


### PR DESCRIPTION
The issue is that decorators for our bazman REST end point do not respond favorably to memory profiling. Somehow interaction with memory profiler consistently corrupts data on request and causes obscure REST errors. In order to be able to exclude memory profiling from entire packages I added a mechanism that allows user to import a single variable at __init__.py for the package and prevent every method decorated with @expose() to be permanently excluded from memory profiling.