### PR TITLE
Nt 76 memory profiler individual process toggle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ install_requires = [
     "TurboJson >= 1.3.2",
     "TurboKid >= 1.0.5",
     "memory_profiler >= 0.52.0",
-    "fluent-logger >=0.4.4"
+    "fluent-logger >= 0.4.4",
+    "psutil >= 5.4.3"
 ]
 
 exp = ["TGFastData"]

--- a/turbogears/release.py
+++ b/turbogears/release.py
@@ -28,7 +28,7 @@ problem.
     http://svn.turbogears.org/trunk#egg=turbogears-dev
 """
 
-version = "1.0.11.5"
+version = "1.0.11.6"
 description = "Front-to-back, open-source, rapid web development framework"
 long_description = __doc__
 author = "Kevin Dangoor"


### PR DESCRIPTION
Adding precision to control ON/OFF profiling state of every process. The process can be triggered by a script to turn memory_profiling on and off for every process individually.