### PR TITLE
SWAT-77: Force widgets to respect assume_encoding configuration

### DIFF
--- a/turbogears/release.py
+++ b/turbogears/release.py
@@ -28,7 +28,7 @@ problem.
     http://svn.turbogears.org/trunk#egg=turbogears-dev
 """
 
-version = "1.0.11.11"
+version = "1.0.11.12"
 description = "Front-to-back, open-source, rapid web development framework"
 long_description = __doc__
 author = "Kevin Dangoor"

--- a/turbogears/widgets/base.py
+++ b/turbogears/widgets/base.py
@@ -276,6 +276,8 @@ class Widget(object):
 
         if not params.get('name'):
             params['name'] = self.name
+        if 'assume_encoding' not in params:
+            params['assume_encoding'] = config.get('kid.assume_encoding', 'utf-8')
         params['value'] = to_unicode(self.adjust_value(value, **params))
         self.update_params(params)
         # update_data has been deprecated

--- a/turbogears/widgets/tests/test_widgets.py
+++ b/turbogears/widgets/tests/test_widgets.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import itertools
 
 import cherrypy
@@ -691,3 +692,14 @@ def test_selectfield_with_with_non_iterable_option_elements():
     assert '<option selected="selected" value="python">' in output
     assert '<option value="java">' in output
     assert '<option value="pascal">' in output
+
+
+def test_widget_with_nonascii_characters():
+    class MyWidget(widgets.Widget):
+        template = """<div>${my_param}</div>"""
+        params = ['my_param']
+
+    my_param = 'é'
+    element = MyWidget().display(my_param=my_param)
+    assert element.tag == u'div'
+    assert element.text == u'é'


### PR DESCRIPTION
Widgets were not using the `assume_encoding` parameter and instead
defaulting to the system default which was ASCII.  The parent templates
would be fine but widgets would explode.  This change is fairly minor
and only ensures that the configuration is respected for widgets as
well.